### PR TITLE
Add handling zero DateInterval

### DIFF
--- a/src/JMS/Serializer/Handler/DateHandler.php
+++ b/src/JMS/Serializer/Handler/DateHandler.php
@@ -218,6 +218,10 @@ class DateHandler implements SubscribingHandlerInterface
             $format .= $dateInterval->s.'S';
         }
 
+        if ('P' === $format) {
+            $format = 'P0D';
+        }
+
         return $format;
     }
 }

--- a/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php
@@ -37,5 +37,9 @@ class DateIntervalFormatTest extends \PHPUnit_Framework_TestCase
         $iso8601DateIntervalString = $dtf->format(new \DateInterval('P2Y4DT6H8M16S'));
 
         $this->assertEquals($iso8601DateIntervalString, 'P2Y4DT6H8M16S');
+        
+        $iso8601DateIntervalString = $dtf->format(new \DateInterval('P0D'));
+
+        $this->assertEquals($iso8601DateIntervalString, 'P0D');
     }
 }


### PR DESCRIPTION
I just copy this PR https://github.com/schmittjoh/serializer/pull/503 and remove the composer.lock conflict

"When DateInterval is zeroed current handler returns 'P', which cannot be converted back to DateInterval object. Adding simple zero value for any part solved my issue."